### PR TITLE
Portability: load stdlib.h instead of malloc.h

### DIFF
--- a/inst/include/flalloc.h
+++ b/inst/include/flalloc.h
@@ -1,7 +1,7 @@
 #ifndef _INC_flalloc
 #define _INC_flalloc
                     
-#include <malloc.h>  
+#include <stdlib.h>  
 #include "fl__types.h"
 
 #define MALLOC   malloc


### PR DESCRIPTION
Fixes compilation on macOS and *BSDs.
Tested on OpenBSD, macOS and Windows.