### PR TITLE
Fix bug when iterations exist but do not start with 1.

### DIFF
--- a/R/flxsa.R
+++ b/R/flxsa.R
@@ -283,7 +283,7 @@ setMethod("FLXSA", signature(stock="FLStock", indices="FLIndices"),
           
         res@stock.n<-propagate(FLQuant(res@stock.n@.Data),iters)
         res@harvest<-propagate(FLQuant(res@harvest@.Data),iters)
-        for (i in as.character(2:iters)) {
+        for (i in (2:iters)) {
           res. <- .Call("runFLXSA", iter(stock,i), lapply(indices, iter,i), control, FALSE)
           iter(res@stock.n,i)<-FLQuant(res.@stock.n@.Data)
           iter(res@harvest,i)<-FLQuant(res.@harvest@.Data)


### PR DESCRIPTION
FLXSA fails if >1 iterations exist but dimnames for iterations do not start with "1".

A minimal reproducible example:
```
library(FLXSA)
data("ple4")
data("ple4.index")
stk <- propagate(ple4, 10)
idx <- propagate(ple4.index, 10)
FLXSA(iter(stk, 6:10), iter(idx, 6:10), diag.flag = FALSE)
```
```
# Error in x@.Data[i, j, k, l, m, n, drop = FALSE] : 
#   subscript out of bounds
```
because the loop in https://github.com/flr/FLXSA/blob/e50a08af3d5853b2f36c3bd0ecad48418e2ada17/R/flxsa.R#L286
always starts with `"2"` (which might not exist) instead of `2`.
